### PR TITLE
Fix null pointer dereference in bridge.c

### DIFF
--- a/vmnet-only/bridge.c
+++ b/vmnet-only/bridge.c
@@ -591,16 +591,17 @@ VNetBridgeReceiveFromVNet(VNetJack        *this, // IN: jack
 
    dev_lock_list();
    // added line
+   bool found = false
    for_each_netdev_rcu(&init_net, dev) {
       if (MAC_EQ(dest, dev->dev_addr) ||
           skb->len > dev->mtu + dev->hard_header_len) {
-         continue;
+        found = true;
+	break;
       }
       // Your existing code here (for sending down)
    }
    dev_unlock_list();
-   if (MAC_EQ(dest, dev->dev_addr) ||
-       skb->len > dev->mtu + dev->hard_header_len) {
+   if (found) {
       dev_unlock_list();
    } else {
 #     if 0 // XXX we should do header translation


### PR DESCRIPTION
On 6.10+, we null pointer dereference when the packet is for us because the for loop does not guarantee that dev will stay valid when it ends, and we then try to memcmp a NULL dev_addr.

By setting a flag we also simplify the logic - it's not obvious at first glance that the loop was used for the side effect of finding dev, especially since we also redo the comparison since a few lines below.

Feel free to fix this however you want, i just wanted to offer a patch that worked :)
